### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/DFRobot_HT1632C/keywords.txt
+++ b/DFRobot_HT1632C/keywords.txt
@@ -6,37 +6,37 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DFRobot_HT1632C			KEYWORD1
+DFRobot_HT1632C	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin			KEYWORD2
-clrPixel		KEYWORD2
+begin	KEYWORD2
+clrPixel	KEYWORD2
 setPixel	KEYWORD2
 
 isBlinkEnable	KEYWORD2
 inLowpower	KEYWORD2
-isLedOn			KEYWORD2
-setPwm		KEYWORD2
+isLedOn	KEYWORD2
+setPwm	KEYWORD2
 
-clearScreen			KEYWORD2
-fillScreen		KEYWORD2
-writeScreen		KEYWORD2
+clearScreen	KEYWORD2
+fillScreen	KEYWORD2
+writeScreen	KEYWORD2
 
-drawLine			KEYWORD2
-clrLine		KEYWORD2
-getTextWidth		KEYWORD2
+drawLine	KEYWORD2
+clrLine	KEYWORD2
+getTextWidth	KEYWORD2
 
-drawText			KEYWORD2
-setCursor		KEYWORD2
-setFont		KEYWORD2
+drawText	KEYWORD2
+setCursor	KEYWORD2
+setFont	KEYWORD2
 
-print		KEYWORD2
+print	KEYWORD2
 
-FONT5X4		KEYWORD2
-FONT8X4		KEYWORD2
+FONT5X4	KEYWORD2
+FONT8X4	KEYWORD2
 
 FONT_8X4	KEYWORD2
 FONT_8X4_END	KEYWORD2
@@ -47,5 +47,5 @@ ONT_8X4_HEIGHT	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-COM_SIZE		LITERAL1
-OUT_SIZE		LITERAL1
+COM_SIZE	LITERAL1
+OUT_SIZE	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords